### PR TITLE
Add support for `inline` option to inject contents of file rather than file path into `fileTmpl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ Default value: `false`
 
 Reference files using a relative url.
 
+#### options.inline
+Type: `Boolean`
+Default value: `false`
+
+Pass the contents of a file rather than the filepath into `fileTmpl`.  For example, if `options.inline` is set to `true` and `fileTmpl` is set to `<script>%s</script>`, the script contents will be injected between `<script>` tags.
+

--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -22,7 +22,8 @@ module.exports = function(grunt) {
 			endTag: '<!--SCRIPTS END-->',
 			fileTmpl: '<script src="%s"></script>',
 			appRoot: '',
-			relative: false
+			relative: false,
+			inline: false
 		});
 
 
@@ -42,6 +43,10 @@ module.exports = function(grunt) {
 						return false;
 					} else { return true; }
 				}).map(function (filepath) {
+					if (options.inline) {
+						var contents = grunt.file.read(filepath);
+						return util.format(options.fileTmpl, contents);
+					}
 					filepath = filepath.replace(options.appRoot, '');
 					// If "relative" option is set, remove initial forward slash from file path
 					if (options.relative) {


### PR DESCRIPTION
Example of use:

```
prodJs: {
  options: {
    startTag: '<!--SCRIPTS-->',
    endTag: '<!--SCRIPTS END-->',
    fileTmpl: "<script>\n%s\n</script>\n",
    appRoot: '.tmp/public',
    inline: true
  },
  files: {
    '.tmp/public/**/*.html': ['.tmp/public/min/production.min.js'],
    'views/**/*.html': ['.tmp/public/min/production.min.js'],
    'views/**/*.ejs': ['.tmp/public/min/production.min.js']
  }
}
```

Running this task outputs the contents of each script file between `<script>` tags as an inline script on the page.  This can greatly reduce page load times by reducing the number of HTTP requests performed on page load.
